### PR TITLE
Implementing a slot in Link component

### DIFF
--- a/examples/lwc/customLink/lwc/mainMenuLink/mainMenuLink.js
+++ b/examples/lwc/customLink/lwc/mainMenuLink/mainMenuLink.js
@@ -1,11 +1,11 @@
+import { Link } from 'c/lwcRouter';
 import { api } from 'lwc';
-import {Link} from 'c/lwcRouter';
 
 export default class MainMenuLink extends Link {
     @api path;
     @api label;
 
-    connectedCallback(){
+    connectedCallback() {
         //Call the connectedCallback method of the parent class.
         super.connectedCallback();
 
@@ -18,17 +18,17 @@ export default class MainMenuLink extends Link {
      * Otherwise, no need to write handler method.
      * You can directly use {handleClick} in the html file
      */
-    handleClick(){
-        super.handleClick();
+    handleClick(e) {
+        super.handleClick(e);
         //Some custom logic if you needed.
     }
 
-    get activeClass(){
+    get activeClass() {
         let strClass = 'slds-button';
 
-        // this.currentPath variable is the Link class property. 
-        // You can use this variable to match with your path. 
-        if(this.currentPath == this.path){
+        // this.currentPath variable is the Link class property.
+        // You can use this variable to match with your path.
+        if (this.currentPath == this.path) {
             strClass += ' active-class';
         }
         return strClass;

--- a/force-app/main/default/lwc/link/link.html
+++ b/force-app/main/default/lwc/link/link.html
@@ -1,3 +1,5 @@
 <template>
-    <lightning-button variant={variant} label={label} title={title} onclick={handleClick} class="slds-m-left_x-small"></lightning-button>
+    <slot onclick={handleClick}>
+        <lightning-button variant={variant} label={label} title={title} class="slds-m-left_x-small"></lightning-button>
+    </slot>
 </template>

--- a/force-app/main/default/lwc/link/link.js
+++ b/force-app/main/default/lwc/link/link.js
@@ -1,5 +1,5 @@
 import { LightningElement, api, track } from 'lwc';
-import {dispatchEvent, getRouteMatch, REGISTER_ROUTER_EVENT_NAME} from 'c/lwcRouterUtil';
+import { REGISTER_ROUTER_EVENT_NAME, dispatchEvent, getRouteMatch } from 'c/lwcRouterUtil';
 export default class Link extends LightningElement {
     @api label;
     @api to = '*';
@@ -9,30 +9,31 @@ export default class Link extends LightningElement {
     @track currentPath;
     @track unsubscribe;
     parentUrl
-    async connectedCallback(){
-        await getRouteMatch(this, ({path, url}) => {
+    async connectedCallback() {
+        await getRouteMatch(this, ({ path, url }) => {
             this.parentUrl = url;
-            if(this.to.indexOf(':url') > -1){
+            if (this.to.indexOf(':url') > -1) {
                 this.to = this.to.replace(':url', this.parentUrl);
             }
         })
         await dispatchEvent(REGISTER_ROUTER_EVENT_NAME, this, async (routerInstance) => {
             this.routerInstance = routerInstance;
             this.currentPath = this.routerInstance.currentPath;
-            this.unsubscribe = this.routerInstance.subscribe(this,this.setCurrentPath.bind(this))
+            this.unsubscribe = this.routerInstance.subscribe(this, this.setCurrentPath.bind(this))
         })
     }
-    setCurrentPath (){
+    setCurrentPath() {
         this.currentPath = this.routerInstance.currentPath;
     }
-    handleClick(){
-        if(this.to){
+    handleClick(e) {
+        e.stopPropagation();
+        if (this.to) {
             this.routerInstance.currentPath = this.to;
             this.currentPath = this.to;
         }
     }
-    disconnectedCallback(){
-        if(this.unsubscribe){
+    disconnectedCallback() {
+        if (this.unsubscribe) {
             this.unsubscribe.unsubscribe();
         }
     }


### PR DESCRIPTION
Adds a slot to the link component so the consumer can define what the clickable element is that should be used to trigger the navigation event.
The original api is preserved and the slot defaults to the original lightning button if no other element is provided.