### PR TITLE
Automatically add active class to slotted element in Link component

### DIFF
--- a/force-app/main/default/lwc/link/link.html
+++ b/force-app/main/default/lwc/link/link.html
@@ -1,5 +1,5 @@
 <template>
-    <slot onclick={handleClick}>
+    <slot onclick={handleClick} onslotchange={handleSlotChange}>
         <lightning-button variant={variant} label={label} title={title} class="slds-m-left_x-small"></lightning-button>
     </slot>
 </template>

--- a/force-app/main/default/lwc/link/link.js
+++ b/force-app/main/default/lwc/link/link.js
@@ -27,7 +27,7 @@ export default class Link extends LightningElement {
         return this._activeClass;
     }
     set activeClass(value) {
-        this._activeClass = String(value).split(' ');
+        this._activeClass = String(value).split(' ').filter(value => !!value);
     }
 
     async connectedCallback() {

--- a/force-app/main/default/lwc/link/link.js
+++ b/force-app/main/default/lwc/link/link.js
@@ -15,16 +15,16 @@ export default class Link extends LightningElement {
 
     @api
     get active() {
-        return this._active;
+        return !!this._active;
     }
     set active(value) {
-        this._active = value;
+        this._active = !!value;
         this.toggleActiveAttributes(this._active);
     }
 
     @api
     get activeClass() {
-        return this._activeClass;
+        return this._activeClass || [];
     }
     set activeClass(value) {
         this._activeClass = String(value).split(' ').filter(value => !!value);

--- a/force-app/main/default/lwc/link/link.js
+++ b/force-app/main/default/lwc/link/link.js
@@ -1,9 +1,9 @@
-import { LightningElement, api, track } from 'lwc';
-import { REGISTER_ROUTER_EVENT_NAME, dispatchEvent, getRouteMatch } from 'c/lwcRouterUtil';
+import {LightningElement, api, track} from 'lwc';
+import {REGISTER_ROUTER_EVENT_NAME, dispatchEvent, getRouteMatch} from 'c/lwcRouterUtil';
 
 export default class Link extends LightningElement {
     @api label;
-    @api to = '*';
+    @api to      = '*';
     @api variant = 'base';
     @api title;
     @track routerInstance;
@@ -31,7 +31,7 @@ export default class Link extends LightningElement {
     }
 
     async connectedCallback() {
-        await getRouteMatch(this, ({ path, url }) => {
+        await getRouteMatch(this, ({path, url}) => {
             this.parentUrl = url;
             if (this.to.indexOf(':url') > -1) {
                 this.to = this.to.replace(':url', this.parentUrl);
@@ -39,9 +39,9 @@ export default class Link extends LightningElement {
         })
         await dispatchEvent(REGISTER_ROUTER_EVENT_NAME, this, async (routerInstance) => {
             this.routerInstance = routerInstance;
-            this.currentPath = this.routerInstance.currentPath;
-            this.unsubscribe = this.routerInstance.subscribe(this, this.setCurrentPath.bind(this))
-            this.active = this.currentPath === this.to;
+            this.currentPath    = this.routerInstance.currentPath;
+            this.unsubscribe    = this.routerInstance.subscribe(this, this.setCurrentPath.bind(this))
+            this.active         = this.currentPath === this.to;
         })
     }
     renderedCallback() {
@@ -56,7 +56,7 @@ export default class Link extends LightningElement {
         e.stopPropagation();
         if (this.to) {
             this.routerInstance.currentPath = this.to;
-            this.currentPath = this.to;
+            this.currentPath                = this.to;
         }
     }
     handleSlotChange() {
@@ -65,6 +65,7 @@ export default class Link extends LightningElement {
     }
     setCurrentPath() {
         this.currentPath = this.routerInstance.currentPath;
+        this.active = this.currentPath === this.to;
     }
     captureSlottedElement() {
         this._slottedElement = this.querySelector('*');

--- a/force-app/main/default/lwc/link/link.js
+++ b/force-app/main/default/lwc/link/link.js
@@ -1,9 +1,9 @@
-import {LightningElement, api, track} from 'lwc';
-import {REGISTER_ROUTER_EVENT_NAME, dispatchEvent, getRouteMatch} from 'c/lwcRouterUtil';
+import { LightningElement, api, track } from 'lwc';
+import { REGISTER_ROUTER_EVENT_NAME, dispatchEvent, getRouteMatch } from 'c/lwcRouterUtil';
 
 export default class Link extends LightningElement {
     @api label;
-    @api to      = '*';
+    @api to = '*';
     @api variant = 'base';
     @api title;
     @track routerInstance;
@@ -31,7 +31,7 @@ export default class Link extends LightningElement {
     }
 
     async connectedCallback() {
-        await getRouteMatch(this, ({path, url}) => {
+        await getRouteMatch(this, ({ path, url }) => {
             this.parentUrl = url;
             if (this.to.indexOf(':url') > -1) {
                 this.to = this.to.replace(':url', this.parentUrl);
@@ -39,9 +39,9 @@ export default class Link extends LightningElement {
         })
         await dispatchEvent(REGISTER_ROUTER_EVENT_NAME, this, async (routerInstance) => {
             this.routerInstance = routerInstance;
-            this.currentPath    = this.routerInstance.currentPath;
-            this.unsubscribe    = this.routerInstance.subscribe(this, this.setCurrentPath.bind(this))
-            this.active         = this.currentPath === this.to;
+            this.currentPath = this.routerInstance.currentPath;
+            this.unsubscribe = this.routerInstance.subscribe(this, this.setCurrentPath.bind(this))
+            this.active = this.currentPath === this.to;
         })
     }
     renderedCallback() {
@@ -56,7 +56,7 @@ export default class Link extends LightningElement {
         e.stopPropagation();
         if (this.to) {
             this.routerInstance.currentPath = this.to;
-            this.currentPath                = this.to;
+            this.currentPath = this.to;
         }
     }
     handleSlotChange() {

--- a/force-app/main/default/lwc/link/link.js
+++ b/force-app/main/default/lwc/link/link.js
@@ -1,5 +1,6 @@
 import { LightningElement, api, track } from 'lwc';
-import {dispatchEvent, getRouteMatch, REGISTER_ROUTER_EVENT_NAME} from 'c/lwcRouterUtil';
+import { REGISTER_ROUTER_EVENT_NAME, dispatchEvent, getRouteMatch } from 'c/lwcRouterUtil';
+
 export default class Link extends LightningElement {
     @api label;
     @api to = '*';
@@ -9,30 +10,47 @@ export default class Link extends LightningElement {
     @track currentPath;
     @track unsubscribe;
     parentUrl
-    async connectedCallback(){
-        await getRouteMatch(this, ({path, url}) => {
+    @api
+    get active() {
+        return this._active;
+    }
+    set active(value) {
+        this._active = value;
+        this.toggleActiveAttribute();
+    }
+    async connectedCallback() {
+        await getRouteMatch(this, ({ path, url }) => {
             this.parentUrl = url;
-            if(this.to.indexOf(':url') > -1){
+            if (this.to.indexOf(':url') > -1) {
                 this.to = this.to.replace(':url', this.parentUrl);
             }
         })
         await dispatchEvent(REGISTER_ROUTER_EVENT_NAME, this, async (routerInstance) => {
             this.routerInstance = routerInstance;
             this.currentPath = this.routerInstance.currentPath;
-            this.unsubscribe = this.routerInstance.subscribe(this,this.setCurrentPath.bind(this))
+            this.unsubscribe = this.routerInstance.subscribe(this, this.setCurrentPath.bind(this))
+            this.active = this.currentPath === this.to;
         })
     }
-    setCurrentPath (){
+    setCurrentPath() {
         this.currentPath = this.routerInstance.currentPath;
     }
-    handleClick(){
-        if(this.to){
+    toggleActiveAttribute() {
+        if (this.active) {
+            this.setAttribute("active", "");
+        } else {
+            this.removeAttribute("active");
+        }
+    }
+    handleClick(e) {
+        e.stopPropagation();
+        if (this.to) {
             this.routerInstance.currentPath = this.to;
             this.currentPath = this.to;
         }
     }
-    disconnectedCallback(){
-        if(this.unsubscribe){
+    disconnectedCallback() {
+        if (this.unsubscribe) {
             this.unsubscribe.unsubscribe();
         }
     }

--- a/force-app/main/default/lwc/link/link.js
+++ b/force-app/main/default/lwc/link/link.js
@@ -10,14 +10,26 @@ export default class Link extends LightningElement {
     @track currentPath;
     @track unsubscribe;
     parentUrl
+    _slottedElement;
+    _activeClass = ['link-active-class'];
+
     @api
     get active() {
         return this._active;
     }
     set active(value) {
         this._active = value;
-        this.toggleActiveAttribute();
+        this.toggleActiveAttributes(this._active);
     }
+
+    @api
+    get activeClass() {
+        return this._activeClass;
+    }
+    set activeClass(value) {
+        this._activeClass = String(value).split(' ');
+    }
+
     async connectedCallback() {
         await getRouteMatch(this, ({ path, url }) => {
             this.parentUrl = url;
@@ -35,12 +47,22 @@ export default class Link extends LightningElement {
     setCurrentPath() {
         this.currentPath = this.routerInstance.currentPath;
     }
-    toggleActiveAttribute() {
+    toggleActiveAttributes() {
         if (this.active) {
             this.setAttribute("active", "");
+            this.applyActiveClassTo(this._slottedElement);
         } else {
             this.removeAttribute("active");
+            this.removeActiveClassFrom(this._slottedElement);
         }
+    }
+    applyActiveClassTo(element) {
+        if (!element) return;
+        this.activeClass.forEach(activeClass => element.classList.add(activeClass));
+    }
+    removeActiveClassFrom(element) {
+        if (!element) return;
+        this.activeClass.forEach(activeClass => element.classList.remove(activeClass));
     }
     handleClick(e) {
         e.stopPropagation();
@@ -48,6 +70,9 @@ export default class Link extends LightningElement {
             this.routerInstance.currentPath = this.to;
             this.currentPath = this.to;
         }
+    }
+    renderedCallback() {
+        this._slottedElement = this.querySelector('*');
     }
     disconnectedCallback() {
         if (this.unsubscribe) {

--- a/force-app/main/default/lwc/link/link.js
+++ b/force-app/main/default/lwc/link/link.js
@@ -1,5 +1,6 @@
 import { LightningElement, api, track } from 'lwc';
 import { REGISTER_ROUTER_EVENT_NAME, dispatchEvent, getRouteMatch } from 'c/lwcRouterUtil';
+
 export default class Link extends LightningElement {
     @api label;
     @api to = '*';
@@ -43,8 +44,30 @@ export default class Link extends LightningElement {
             this.active = this.currentPath === this.to;
         })
     }
+    renderedCallback() {
+        this.captureSlottedElement();
+    }
+    disconnectedCallback() {
+        if (this.unsubscribe) {
+            this.unsubscribe.unsubscribe();
+        }
+    }
+    handleClick(e) {
+        e.stopPropagation();
+        if (this.to) {
+            this.routerInstance.currentPath = this.to;
+            this.currentPath = this.to;
+        }
+    }
+    handleSlotChange() {
+        this.captureSlottedElement();
+        this.toggleActiveAttributes();
+    }
     setCurrentPath() {
         this.currentPath = this.routerInstance.currentPath;
+    }
+    captureSlottedElement() {
+        this._slottedElement = this.querySelector('*');
     }
     toggleActiveAttributes() {
         if (this.active) {
@@ -62,20 +85,5 @@ export default class Link extends LightningElement {
     removeActiveClassFrom(element) {
         if (!element) return;
         this.activeClass.forEach(activeClass => element.classList.remove(activeClass));
-    }
-    handleClick(e) {
-        e.stopPropagation();
-        if (this.to) {
-            this.routerInstance.currentPath = this.to;
-            this.currentPath = this.to;
-        }
-    }
-    renderedCallback() {
-        this._slottedElement = this.querySelector('*');
-    }
-    disconnectedCallback() {
-        if (this.unsubscribe) {
-            this.unsubscribe.unsubscribe();
-        }
     }
 }


### PR DESCRIPTION
### Active attribute

Implemented reflection of an "active" attribute on the Link component when the link is active.  This allows for the parent to apply styles to any content in the Link slot of the active links.

For example, if the currentPath was "/about" the `About` anchor tag slotted in the Link component would be bold. 
  
exampleComponent.html
```html
<c-router>
  <c-link to="/about" active>
    <a>About</a>
  </c-link>
  <c-link to="/contact">
    <a>Contact</a>
  </c-link>
</c-router>
```

exampleComponent.css
```css
c-link[active] a {
  font-weight: bold;
}
```

### Automatic active class assignment

Implemented automatic active class assignment to the top level element slotted in the Link component when the link is active.  By default the class name "link-active-class" is applied.

For example, if the currentPath is "/about" the content slotted in the about Link component will have link-active-class automatically added to it.
  
exampleComponent.html
```html
<c-router>
  <c-link to="/about" active>
    <a class="link-active-class">About</a>
  </c-link>
  <c-link to="/contact" active>
    <a>Contact</a>
  </c-link>
</c-router>
```

exampleComponent.css
```css
.link-active-class {
  color: red;
}
```

In the case that we want to apply specific classes (e.g. SLDS classes) to the slotted content, we can set the "active-class" attribute on the Link component.  The provided class name is automatically added to the content in the slot.

exampleComponent.html
```html
<c-router>
  <c-link to="/about" active-class="slds-text-title_caps" active>
    <a class="slds-text-title_caps">About</a>
  </c-link>
  <c-link to="/contact" active-class="slds-text-title_caps">
    <a>Contact Us</a>
  </c-link>
</c-router>
```

The activeClass prop can also accept multiple classes separated by spaces.

exampleComponent.html
```html
<c-router>
  <c-link to="/about" active-class="slds-text-title_caps slds-truncate" active>
    <a class="slds-text-title_caps slds-truncate">About</a>
  </c-link>
  <c-link to="/contact" active-class="slds-text-title_caps slds-truncate">
    <a>Contact</a>
  </c-link>
</c-router>
```

The active class will also be updated when the content in the slot is changed.  For example, if we have conditionally rendered content, the activeClass would be re-applied when the condition changes. 

exampleComponent.html
```html
<c-router>
  <c-link to="/about" active-class="slds-text-title_caps slds-truncate" active>
    <template if:true={showMyProfile}>
      <a class="slds-text-title_caps slds-truncate">My Profile</a>
    </template>
    <template if:false={showMyProfile}>
      <a class="slds-text-title_caps slds-truncate">About</a>
    </template>
  </c-link>
</c-router>
```
